### PR TITLE
add ctags file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .idea/
 .vscode/
 
+tags
+
 cmake-*/
 build*/


### PR DESCRIPTION
My neovim setup uses ctags which let me jump to function declarations with `C-]`. Committing this file is silly. 
